### PR TITLE
game time parsing and signalr client fixes

### DIFF
--- a/signalr_test.go
+++ b/signalr_test.go
@@ -43,3 +43,35 @@ func TestSignalRClient(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"foo":"bar"}`, string(resp))
 }
+
+func TestSignalRClient_UnexpectedClosure(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/negotiate" {
+			w.Write([]byte(`{"Url":"/","ConnectionToken":"token","TryWebSockets":true}`))
+		} else if r.URL.Path == "/connect" {
+			conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+			require.NoError(t, err)
+
+			messageType, p, err := conn.ReadMessage()
+			require.NoError(t, err)
+			assert.Equal(t, websocket.TextMessage, messageType)
+			require.JSONEq(t, `{"H": "schedulehub", "M": "RegisterForSchedule", "A":["2019","REG",3], "I":0}`, string(p))
+
+			conn.Close()
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := &SignalRClient{
+		URL:            ts.URL,
+		ConnectionData: `[{"name":"gamestatshub"},{"name":"schedulehub"}]`,
+	}
+
+	conn, err := c.Connection()
+	require.NoError(t, err)
+
+	_, err = conn.Invoke(context.Background(), "schedulehub", "RegisterForSchedule", "2019", "REG", 3)
+	assert.Error(t, ErrSignalRConnectionClosed)
+}

--- a/stat_file.go
+++ b/stat_file.go
@@ -675,7 +675,10 @@ func (t *GameTime) unmarshal(s string) error {
 		return fmt.Errorf("unsupported clock time string: %s", s)
 	}
 	newTime := GameTime{}
-	if v, err := strconv.Atoi(minutes); err != nil {
+	if minutes == "" {
+		zero := 0
+		newTime.minutes = &zero
+	} else if v, err := strconv.Atoi(minutes); err != nil {
 		return fmt.Errorf("error unmarshaling game time minutes: %w", err)
 	} else {
 		newTime.minutes = &v

--- a/stat_file_test.go
+++ b/stat_file_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,10 @@ func TestStatFile(t *testing.T) {
 
 	var stats StatFile
 	require.NoError(t, json.NewDecoder(f).Decode(&stats))
+
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 
 	files, err := ioutil.ReadDir("testdata/games")
 	require.NoError(t, err)
@@ -130,5 +135,22 @@ func TestStatFile_Update(t *testing.T) {
 
 			assert.Equal(t, expected, statFile)
 		})
+	}
+}
+
+func TestGameTime(t *testing.T) {
+	for input, expected := range map[string]time.Duration{
+		"01:02": time.Minute + 2*time.Second,
+		"0102":  time.Minute + 2*time.Second,
+		"102":   time.Minute + 2*time.Second,
+		"1:12":  time.Minute + 12*time.Second,
+		":12":   12 * time.Second,
+		"12":    12 * time.Second,
+	} {
+		buf, err := json.Marshal(input)
+		require.NoError(t, err)
+		var actual GameTime
+		require.NoError(t, json.Unmarshal(buf, &actual), err)
+		assert.Equal(t, expected, actual.Duration())
 	}
 }


### PR DESCRIPTION
* Noticed in the play feed logs there were errors with under a minute remaining. Strings like ":30" now parse as game times.
* Noticed that normal SignalR connection close errors were being logged. These are no longer logged as they're expected behavior.
* When fixing the close error logging I realized that we weren't aborting SignalR invocations on connection closure. The added unit test previously just deadlocked forever.