### PR TITLE
return file number for incremental stat file

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -33,9 +33,10 @@ func TestClientIntegration(t *testing.T) {
 	})
 
 	t.Run("GetIncrementalStatFileXML", func(t *testing.T) {
-		statFile, statFileTime, err := c.GetIncrementalStatFile(20191229, "SEA", 100)
+		statFile, number, statFileTime, err := c.GetIncrementalStatFile(20191229, "SEA", 100)
 		require.NoError(t, err)
 		assert.Len(t, statFile.Play, 1)
+		assert.Equal(t, 100, number)
 		assert.Equal(t, time.Date(2019, time.December, 30, 2, 23, 23, 0, time.UTC), statFileTime)
 	})
 


### PR DESCRIPTION
The file number in the header for https://entry.nflgsis.com/DataInterfaceServer/20200920/LAC/StatXML/0 seems to be right. We can use it in Fusion Feed instead of the number in the XML.